### PR TITLE
fix function definition for Import-WifiProfiles

### DIFF
--- a/WifiTools.ps1
+++ b/WifiTools.ps1
@@ -160,7 +160,7 @@ function Export-WifiProfiles
 
 }
 
-Import-WifiProfiles
+function Import-WifiProfiles
 {
 <#
 


### PR DESCRIPTION
`Import-WifiProfiles` was missing the function keyword in source.

resolves #1